### PR TITLE
Fedora support

### DIFF
--- a/packages/osfamilymap.yaml
+++ b/packages/osfamilymap.yaml
@@ -16,8 +16,12 @@ RedHat:
         - epel
       pkgs:
         - gcc
-        - python-devel
         - python2-pip
+     {% if salt['grains.get']('os') == 'Fedora' %}
+        - python2-devel
+     {%- else %}
+        - python-devel
+     {%- endif %}
   gems:
     required:
       pkgs:


### PR DESCRIPTION
Formula failed on Fedora.
```
         ID: pip_req_pkgs
    Function: pkg.installed
      Result: False
     Comment: The following packages failed to install/update: python-devel
              The following packages were already installed: gcc, python2-pip
     Started: 07:32:02.070554
    Duration: 56077.401 ms
     Changes:
```
Need to reference correct package name for Fedora.  
`python2-devel.x86_64 : Libraries and header files needed for Python 2 development`

Centos is correct (for now).
`python-devel.x86_64 : The libraries and header files needed for Python development`
