### PR TITLE
Add fedora support in an osmap

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,10 +9,11 @@ driver_config:
 
 platforms:
   - name: debian-9
+  - name: ubuntu-17.10
+  - name: fedora-27
   - name: centos-7
     driver_config:
       image: saltstack/centos-7-minimal
-  - name: ubuntu-17.10
 
 provisioner:
   name: salt_solo
@@ -30,6 +31,10 @@ provisioner:
       base:
         '*':
           - packages
+  state_top:
+    base:
+      '*':
+        - packages
 
 verifier:
   name: inspec
@@ -41,14 +46,24 @@ verifier:
 
 suites:
   - name: deb
-    provisioner:
-      state_top:
-        base:
-          '*':
-            - packages
     excludes:
       - centos-7
-  - name: rpm
+      - fedora-27
+
+  - name: fedora
+    excludes:
+      - debian-9
+      - ubuntu-17.10
+      - centos-7
+    provisioner:
+      pillars-from-files:
+        packages.sls: test/integration/default/pillar.example.redhat
+
+  - name: centos
+    excludes:
+      - debian-9
+      - ubuntu-17.10
+      - fedora-27
     provisioner:
       dependencies:
         - name: epel
@@ -69,7 +84,3 @@ suites:
             - packages
         epel.sls:
           disabled: false
-    excludes:
-      - debian-9
-      - ubuntu-17.10
-

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,3 +4,7 @@ packages formula
 0.0.1 (2018-02-12)
 
 - Initial version
+
+0.0.2 (2018-02-23)
+
+- Add Fedora support

--- a/README.rst
+++ b/README.rst
@@ -105,5 +105,6 @@ Tested on
 
 * Debian/9
 * Centos/7
+* Fedora/27
 * Ubuntu/17.10
 

--- a/packages/map.jinja
+++ b/packages/map.jinja
@@ -3,13 +3,18 @@
 
 {% import_yaml 'packages/defaults.yaml' as defaults %}
 {% import_yaml 'packages/osfamilymap.yaml' as osfamilymap %}
+{% import_yaml 'packages/osmap.yaml' as osmap %}
 
 {% set packages = salt['grains.filter_by'](
     defaults,
-    merge=salt['grains.filter_by'](
+    merge = salt['grains.filter_by'](
         osfamilymap,
         grain='os_family',
-        merge=salt['pillar.get']('packages', {}),
+        merge = salt['grains.filter_by'](
+            osmap,
+            grain='os',
+            merge = salt['pillar.get']('packages', {}),
+        ),
     ),
     base='packages')
 %}

--- a/packages/osmap.yaml
+++ b/packages/osmap.yaml
@@ -1,0 +1,9 @@
+Fedora:
+  pips:
+    required:
+      states: []
+      pkgs:
+        - gcc
+        - python2-pip
+        - python2-devel
+


### PR DESCRIPTION
As @aboe76 [suggested](https://github.com/saltstack-formulas/packages-formula/pull/5#issuecomment-368254418), added Fedora support in an `osmap.yaml` file.
