### PR TITLE
no native snapd package on Centos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,10 @@ You can specify:
 * ``required states`` on which any of the ``wanted`` packages depend for their
   correct installation (ie, ``epel`` for RedHat families).
 
+.. note::
+
+    Centos has no native ``snapd`` package at this time.
+
 ``packages.remote_pkgs``
 ------------------------
 

--- a/packages/osmap.yaml
+++ b/packages/osmap.yaml
@@ -13,3 +13,8 @@ Fedora:
   snaps:
     collides: ['snap',]
     symlink: True
+
+Centos:
+  snaps:
+    package:
+

--- a/packages/snaps.sls
+++ b/packages/snaps.sls
@@ -6,7 +6,8 @@
 {% set wanted_snaps = packages.snaps.wanted %}
 {% set unwanted_snaps = packages.snaps.unwanted %}
 
-{% if packages.snaps.wanted or packages.snaps.unwanted %}
+{%- if packages.snaps.package %}
+  {% if packages.snaps.wanted or packages.snaps.unwanted %}
 
 ### REQ PKGS (without this, SNAPS can fail to install/uninstall)
 include:
@@ -81,4 +82,5 @@ packages-snapd-{{ snap }}-unwanted:
       - pkg: unwanted_pkgs
   {% endfor %}
 
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
This PR is to ensure snapd state does not run on Centos.

```
ID: pkg_req_pkgs
    Function: pkg.installed
      Result: False
     Comment: Error occurred installing package(s). Additional info follows:

              errors:
                  - Running scope as unit run-16643.scope.
                    Loaded plugins: fastestmirror, versionlock
                    Loading mirror speeds from cached hostfile
                     * base: linux.cc.lehigh.edu
                     * epel: mirror.sfo12.us.leaseweb.net
                     * extras: linux.cc.lehigh.edu
                     * updates: mirror.net.cen.ct.gov
                    No package snapd available.
                    Error: Nothing to do

```