### PR TITLE
add FreeBSD to osfamilymap

### DIFF
--- a/packages/osfamilymap.yaml
+++ b/packages/osfamilymap.yaml
@@ -28,11 +28,12 @@ RedHat:
         - rubygems
 
 FreeBSD:
-  pkgs:
+  pips:
     required:
       pkgs:
         - devel/py-pip
-        - lang/ruby25
   gems:
     required:
-      - devel/ruby-gems
+      pkgs:
+        - lang/ruby25
+        - devel/ruby-gems

--- a/packages/osfamilymap.yaml
+++ b/packages/osfamilymap.yaml
@@ -27,3 +27,12 @@ RedHat:
       pkgs:
         - rubygems
 
+FreeBSD:
+  pkgs:
+    required:
+      pkgs:
+        - devel/py-pip
+        - lang/ruby25
+  gems:
+    required:
+      - devel/ruby-gems


### PR DESCRIPTION
I have not tested on FreeBSD, but this is correct stanza for `osfamilymap.yaml.`