### PR TITLE
Support for 'archive file' format

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,7 +13,7 @@ platforms:
       run_command: /lib/systemd/systemd
       provision_command:
         - apt-get install udev -y
-  - name: ubuntu-17.10
+  - name: ubuntu-18.04
     driver_config:
       run_command: /lib/systemd/systemd
       provision_command:
@@ -64,7 +64,7 @@ suites:
   - name: fedora
     excludes:
       - debian-9
-      - ubuntu-17.10
+      - ubuntu-18.04
       - centos-7
     provisioner:
       pillars-from-files:
@@ -73,7 +73,7 @@ suites:
   - name: centos
     excludes:
       - debian-9
-      - ubuntu-17.10
+      - ubuntu-18.04
       - fedora-27
     provisioner:
       dependencies:

--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,18 @@ You can specify:
 * ``required states`` on which any of the ``wanted`` packages depend for their
   correct installation (ie, ``epel`` for RedHat families).
 
+``packages.archives``
+-------------------
+
+'Archive file` handler for common 'download' and 'checksum' states; extraction state based on `format` value.
+
+* ``wanted`` archive package software, which will be installed by extraction.
+* ``unwanted`` archive package software, which are uninstalled by directory removal.
+* ``required archive packages`` on which any of the ``wanted`` items depend on. Optional.
+
+.. note:: Supports `tar` formats that `salt.states.archive.extracted` understands (tar, rar, zip, etc). The `packages.archives` state can be extended.
+
+
 ``packages.snaps``
 -----------------
 
@@ -164,5 +176,5 @@ Tested on
 * Debian/9
 * Centos/7
 * Fedora/27
-* Ubuntu/17.10
+* Ubuntu/18.04
 

--- a/packages/archives.sls
+++ b/packages/archives.sls
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% from "packages/map.jinja" import packages with context %}
+
+{% set req_packages = packages.pkgs.required.pkgs + ['curl', 'tar', 'bzip2', 'gzip',] %}
+include:
+  - packages.pkgs
+
+extend:
+  pkg_req_pkgs:
+    pkg.installed:
+      - pkgs: {{ req_packages }}
+
+{% set wanted_archives = packages.archives.required.archives %}
+{% do wanted_archives.update( packages.archives.wanted ) %}
+{% set unwanted_archives = packages.archives.unwanted %}
+
+  # unwanted 'archive' software
+{% for file_or_directory in unwanted_archives %}
+packages-archive-unwanted-{{ file_or_directory }}:
+  file.absent:
+    - name: {{ file_or_directory }}
+{% endfor %}
+
+  # wanted 'archive' software
+{% for package, archive in wanted_archives.items() %}
+
+packages-archive-wanted-remove-prev-{{ package }}:
+  file.absent:
+    - name: {{ packages.tmpdir }}/{{ package }}
+    - require_in:
+      - packages-archive-wanted-extract-{{ package }}-directory
+
+packages-archive-wanted-extract-{{ package }}-directory:
+  file.directory:
+    - names:
+      - {{ packages.tmpdir }}/tmp
+      - {{ archive.dest }}
+    - user: {{ 'root' if "user" not in archive else archive.user }}
+    - mode: {{ '0755' if "mode" not in archive else archive.mode }}
+    - makedirs: True
+    - require_in:
+      - cmd: packages-archive-wanted-download-{{ package }}
+
+packages-archive-wanted-download-{{ package }}:
+  cmd.run:
+    - name: curl -s -L -o {{ packages.tmpdir }}/{{ package }} {{ archive.dl.source }}
+    - unless: test -f {{ packages.tmpdir }}/{{ package }}
+
+  {%- if "hashsum" in archive.dl and archive.dl.hashsum %}
+    {# refer to https://github.com/saltstack/salt/pull/41914 #}
+
+packages-archive-wanted-{{ package }}-check-hashsum:
+  module.run:
+    - name: file.check_hash
+    - path: {{ packages.tmpdir }}/{{ package }}
+    - file_hash: {{ archive.dl.hashsum }}
+    - require:
+      - cmd: packages-archive-wanted-download-{{ package }}
+    - require_in:
+      - archive: packages-archive-wanted-install-{{ package }}
+  cmd.run:
+    - name: rm {{ packages.tmpdir }}/{{ package }}
+    - onfail:
+      - module: packages-archive-wanted-{{ package }}-check-hashsum
+  {%- endif %}
+
+packages-archive-wanted-install-{{ package }}:
+  {% if archive.dl.format|trim|lower in ('tar','zip', 'rar',) %}
+
+  archive.extracted:
+    - source: file://{{ packages.tmpdir }}/{{ package }}
+    - name: {{ archive.dest }}
+    - archive_format: {{ archive.dl.format }}
+       {%- if 'hashurl' in archive.dl and archive.dl.hashurl %}
+    - source_hash: {{ archive.dl.hashurl }}
+       {%- endif %}
+       {%- if 'options' in archive and archive.options %}
+    - options: {{ archive.options }}
+    - enforce_toplevel: {{ 'False' if "strip-components" in archive.options else 'True' }}
+       {%- endif %}
+    - unless: test -d {{ archive.dest }}
+  cmd.run:
+    - name: rm {{ packages.tmpdir }}/{{ package }}
+    - onfail:
+      - archive: packages-archive-wanted-install-{{ package }}
+
+  {% else %}
+
+  test.show_notification:
+    - text: |
+        The value of "packages.archives.wanted.{{ package }}.dl.format' is unsupported (skipping {{ package }}).
+
+  {% endif %} 
+    - onchanges:
+      - packages-archive-wanted-download-{{ package }}
+    - require_in:
+      - packages-archive-wanted-cleanup-{{ package }}
+
+packages-archive-wanted-cleanup-{{ package }}:
+  file.absent:
+    - name: {{ packages.tmpdir }}/{{ package }}
+    - onchanges:
+      - packages-archive-wanted-install-{{ package }}
+
+{%- endfor %}

--- a/packages/defaults.yaml
+++ b/packages/defaults.yaml
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 packages:
+  tmpdir: /tmp/saltstack-packages-formula-archives
   remote_pkgs: {}
   pkgs:
     held: {}
@@ -32,3 +33,8 @@ packages:
     required:
       states: []
       pkgs: []
+  archives:
+    wanted: {}    #note: dict
+    unwanted: []
+    required:
+      archives: {}    #note: dict

--- a/packages/init.sls
+++ b/packages/init.sls
@@ -6,4 +6,5 @@ include:
   - packages.remote_pkgs
   - packages.pips
   - packages.gems
+  - packages.archives
   - packages.snaps

--- a/pillar.example
+++ b/pillar.example
@@ -21,6 +21,7 @@ packages:
       - avahi-daemon
     required:
       pkgs:
+        - wget
         - git
   pips:
     wanted:
@@ -45,6 +46,26 @@ packages:
       - test-snapd-hello-classic
     unwanted:
       - goodbye-world
+  archives:
+    wanted:
+      terminator:
+        dest: /usr/local/terminator
+        options: '--strip-components=1'  #recommended option, but beware tarbombs
+        dl:
+          format: tar
+          source: https://launchpad.net/terminator/gtk3/1.91/+download/terminator-1.91.tar.gz
+          #hashurl: https://launchpad.net/terminator/gtk3/1.91/+download/terminator-1.91.tar.gz/+md5
+          hashsum: md5=2eed999d7a41f2e18eaa511bbbf80f58
+      phantomjs:
+        dest: /usr/local/src    #beware tarbombs
+        user: root
+        mode: '0700'
+        dl:
+          format: tar
+          source: https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
+          hashsum: md5=1c947d57fce2f21ce0b43fe2ed7cd361
+    unwanted:
+      - /usr/local/boring_archive_software
 
   remote_pkgs:
     zoom: 'https://zoom.us/client/latest/zoom_amd64.deb'


### PR DESCRIPTION
Resolves #25 
Tested on Centos7 for archives of type `tar`  (tar.gz, tar.bz2).

Sample Pillars
```
packages:
  archives:
    wanted:
      terminator:
        dest: /usr/local/terminator
        dl:
          format: tar.gz
          source: https://launchpad.net/terminator/gtk3/1.91/+download/terminator-1.91.tar.gz
          hashurl: https://launchpad.net/terminator/gtk3/1.91/+download/terminator-1.91.tar.gz/+md5
      phantomjs:
        dest: /usr/local/phantomjs
        user: root
        mode: '0700'
        dl:
          format: tar.bz2
          source: https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
          hashsum: 80e03cfeb22cc4dfe4e73b68ab81c9fdd7c78968cfd5358e6af33960464f15e3
    unwanted:
      - /usr/local/boring_archive_software
```

Sample output
```
local:
----------
          ID: pkg_req_pkgs
    Function: pkg.installed
      Result: True
     Comment: All specified packages are already installed
     Started: 10:14:51.357748
    Duration: 689.41 ms
     Changes:   
----------
          ID: wanted_pkgs
    Function: pkg.installed
      Result: True
     Comment: No packages to install provided
     Started: 10:14:52.047647
    Duration: 0.467 ms
     Changes:   
----------
          ID: unwanted_pkgs
    Function: pkg.purged
      Result: True
     Comment: All specified packages are already absent
     Started: 10:14:52.048220
    Duration: 5.95 ms
     Changes:   
----------
          ID: packages-archive-unwanted-/usr/local/boring_archive_software
    Function: file.absent
        Name: /usr/local/boring_archive_software
      Result: True
     Comment: File /usr/local/boring_archive_software is not present
     Started: 10:14:52.056820
    Duration: 0.303 ms
     Changes:   
----------
          ID: packages-archive-wanted-remove-prev-terminator
    Function: file.absent
        Name: /tmp/terminator
      Result: True
     Comment: File /tmp/terminator is not present
     Started: 10:14:52.057234
    Duration: 0.297 ms
     Changes:   
----------
          ID: packages-archive-wanted-extract-terminator-directory
    Function: file.directory
        Name: /tmp
      Result: True
     Comment: Directory /tmp updated
     Started: 10:14:52.058149
    Duration: 1.018 ms
     Changes:   
              ----------
              mode:
                  0755
----------
          ID: packages-archive-wanted-extract-terminator-directory
    Function: file.directory
        Name: /usr/local/terminator
      Result: True
     Comment: Directory /usr/local/terminator updated
     Started: 10:14:52.059364
    Duration: 1.197 ms
     Changes:   
              ----------
              /usr/local/terminator:
                  New Dir
----------
          ID: packages-archive-wanted-download-terminator
    Function: cmd.run
        Name: wget -O /tmp/terminator https://launchpad.net/terminator/gtk3/1.91/+download/terminator-1.91.tar.gz
      Result: True
     Comment: Command "wget -O /tmp/terminator https://launchpad.net/terminator/gtk3/1.91/+download/terminator-1.91.tar.gz" run
     Started: 10:14:52.062134
    Duration: 8602.385 ms
     Changes:   
              ----------
              pid:
                  6667
              retcode:
                  0
              stderr:
                  --2018-08-22 10:14:52--  https://launchpad.net/terminator/gtk3/1.91/+download/terminator-1.91.tar.gz
                  Resolving launchpad.net (launchpad.net)... 91.189.89.223, 91.189.89.222
                  Connecting to launchpad.net (launchpad.net)|91.189.89.223|:443... connected.
                  HTTP request sent, awaiting response... 303 See Other
                  Location: https://launchpadlibrarian.net/309211351/terminator-1.91.tar.gz [following]
                  --2018-08-22 10:14:52--  https://launchpadlibrarian.net/309211351/terminator-1.91.tar.gz
                  Resolving launchpadlibrarian.net (launchpadlibrarian.net)... 91.189.89.229, 91.189.89.228
                  Connecting to launchpadlibrarian.net (launchpadlibrarian.net)|91.189.89.229|:443... connected.
                  HTTP request sent, awaiting response... 200 OK
                  Length: 910536 (889K) [application/x-tar]
                  Saving to: '/tmp/terminator'
                  
                       0K .......... .......... .......... .......... ..........  5% 1.14M 1s
                      50K .......... .......... .......... .......... .......... 11% 3.03M 0s
                     100K .......... .......... .......... .......... .......... 16% 13.2M 0s
                     150K .......... .......... .......... .......... .......... 22% 2.59M 0s
                     200K .......... .......... .......... .......... .......... 28% 2.56M 0s
                     250K .......... .......... .......... .......... .......... 33% 2.80M 0s
                     300K .......... .......... .......... .......... .......... 39% 2.85M 0s
                     350K .......... .......... .......... .......... .......... 44% 9.41M 0s
                     400K .......... .......... .......... .......... .......... 50% 2.62M 0s
                     450K .......... .......... .......... .......... .......... 56% 2.93M 0s
                     500K .......... .......... .......... .......... .......... 61% 10.8M 0s
                     550K .......... .......... .......... .......... .......... 67% 2.78M 0s
                     600K .......... .......... .......... .......... .......... 73% 2.88M 0s
                     650K .......... .......... .......... .......... .......... 78% 10.5M 0s
                     700K .......... .......... .......... .......... .......... 84% 2.80M 0s
                     750K .......... .......... .......... .......... .......... 89% 4.99M 0s
                     800K .......... .......... .......... .......... .......... 95% 4.67M 0s
                     850K .......... .......... .......... .........            100% 4.52M=0.3s
                  
                  2018-08-22 10:15:00 (3.27 MB/s) - '/tmp/terminator' saved [910536/910536]
              stdout:
----------
          ID: packages-archive-wanted-install-terminator
    Function: archive.extracted
        Name: /usr/local/terminator
      Result: True
     Comment: /tmp/terminator extracted to /usr/local/terminator/, due to absence of one or more files/dirs
     Started: 10:15:00.667548
    Duration: 713.95 ms
     Changes:   
              ----------
              extracted_files:
                  - terminator-1.91
                  - terminator-1.91/terminatorlib
... cut ...

                  - terminator-1.91/data/icons/HighContrast/22x22/apps/terminator-layout.png
                  - terminator-1.91/data/icons/HighContrast/22x22/apps/terminator-custom-commands.png
                  - terminator-1.91/data/icons/HighContrast/22x22/apps/terminator.png
                  - terminator-1.91/data/terminator.desktop.in
----------
          ID: packages-archive-wanted-remove-terminator
    Function: file.absent
        Name: /tmp/terminator
      Result: True
     Comment: Removed file /tmp/terminator
     Started: 10:15:01.382033
    Duration: 0.537 ms
     Changes:   
              ----------
              removed:
                  /tmp/terminator
----------
          ID: packages-archive-wanted-remove-prev-phantomjs
    Function: file.absent
        Name: /tmp/phantomjs
      Result: True
     Comment: File /tmp/phantomjs is not present
     Started: 10:15:01.382678
    Duration: 0.231 ms
     Changes:   
----------
          ID: packages-archive-wanted-extract-phantomjs-directory
    Function: file.directory
        Name: /tmp
      Result: True
     Comment: Directory /tmp updated
     Started: 10:15:01.383305
    Duration: 0.981 ms
     Changes:   
              ----------
              mode:
                  0700
----------
          ID: packages-archive-wanted-extract-phantomjs-directory
    Function: file.directory
        Name: /usr/local/phantomjs
      Result: True
     Comment: Directory /usr/local/phantomjs updated
     Started: 10:15:01.384484
    Duration: 1.295 ms
     Changes:   
              ----------
              /usr/local/phantomjs:
                  New Dir
----------
          ID: packages-archive-wanted-download-phantomjs
    Function: cmd.run
        Name: wget -O /tmp/phantomjs https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
      Result: True
     Comment: Command "wget -O /tmp/phantomjs https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2" run
     Started: 10:15:01.386222
    Duration: 33024.32 ms
     Changes:   
              ----------
              pid:
                  6668
              retcode:
                  0
              stderr:
                  --2018-08-22 10:15:01--  https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
                  Resolving bitbucket.org (bitbucket.org)... 104.192.143.2, 104.192.143.3, 104.192.143.1, ...
                  Connecting to bitbucket.org (bitbucket.org)|104.192.143.2|:443... connected.
                  HTTP request sent, awaiting response... 302 Found
                  Location: https://bbuseruploads.s3.amazonaws.com/fd96ed93-2b32-46a7-9d2b-ecbc0988516a/downloads/396e7977-71fd-4592-8723-495ca4cfa7cc/phantomjs-2.1.1-linux-x86_64.tar.bz2?Signature=q44h7Ez2gW8%2FBt07xwR1KOBfdkw%3D&Expires=1534933560&AWSAccessKeyId=AKIAIQWXW6WLXMB5QZAQ&versionId=null&response-content-disposition=attachment%3B%20filename%3D%22phantomjs-2.1.1-linux-x86_64.tar.bz2%22 [following]
                  --2018-08-22 10:15:02--  https://bbuseruploads.s3.amazonaws.com/fd96ed93-2b32-46a7-9d2b-ecbc0988516a/downloads/396e7977-71fd-4592-8723-495ca4cfa7cc/phantomjs-2.1.1-linux-x86_64.tar.bz2?Signature=q44h7Ez2gW8%2FBt07xwR1KOBfdkw%3D&Expires=1534933560&AWSAccessKeyId=AKIAIQWXW6WLXMB5QZAQ&versionId=null&response-content-disposition=attachment%3B%20filename%3D%22phantomjs-2.1.1-linux-x86_64.tar.bz2%22
                  Resolving bbuseruploads.s3.amazonaws.com (bbuseruploads.s3.amazonaws.com)... 52.216.161.123
                  Connecting to bbuseruploads.s3.amazonaws.com (bbuseruploads.s3.amazonaws.com)|52.216.161.123|:443... connected.
                  HTTP request sent, awaiting response... 200 OK
                  Length: 23415665 (22M) [application/x-tar]
                  Saving to: '/tmp/phantomjs'
                  
                       0K .......... .......... .......... .......... ..........  0%  257K 89s
                      50K .......... .......... .......... .......... ..........  0%  510K 67s
                     100K .......... .......... .......... .......... ..........  0%  526K 59s
                     150K .......... .......... .......... .......... ..........  0%  537K 54s
... cut ....
                   22700K .......... .......... .......... .......... .......... 99%  542K 0s
                   22750K .......... .......... .......... .......... .......... 99%  501K 0s
                   22800K .......... .......... .......... .......... .......... 99%  513K 0s
                   22850K .......... ......                                     100%  233M=31s
                  
                  2018-08-22 10:15:34 (728 KB/s) - '/tmp/phantomjs' saved [23415665/23415665]
              stdout:
----------
          ID: packages-archive-wanted-install-phantomjs
    Function: archive.extracted
        Name: /usr/local/phantomjs
      Result: True
     Comment: /tmp/phantomjs extracted to /usr/local/phantomjs/, due to absence of one or more files/dirs
     Started: 10:15:34.411533
    Duration: 4226.917 ms
     Changes:   
              ----------
              extracted_files:
                  - phantomjs-2.1.1-linux-x86_64
                  - phantomjs-2.1.1-linux-x86_64/examples
                  - phantomjs-2.1.1-linux-x86_64/examples/colorwheel.js
...... cut ....

                  - phantomjs-2.1.1-linux-x86_64/third-party.txt
                  - phantomjs-2.1.1-linux-x86_64/ChangeLog
----------
          ID: packages-archive-wanted-remove-phantomjs
    Function: file.absent
        Name: /tmp/phantomjs
      Result: True
     Comment: Removed file /tmp/phantomjs
     Started: 10:15:38.639138
    Duration: 3.135 ms
     Changes:   
              ----------
              removed:
                  /tmp/phantomjs

Summary for local
-------------
Succeeded: 16 (changed=10)
Failed:     0
-------------
Total states run:     16
Total run time:   47.272 s
```