### PR TITLE
Improved packages.archive state

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -51,7 +51,8 @@ verifier:
   name: inspec
   sudo: false
   # cli, documentation, html, progress, json, json-min, json-rspec, junit
-  reporter: cli
+  reporter:
+    - cli
   inspec_tests:
     - path: test/integration/default
 

--- a/README.rst
+++ b/README.rst
@@ -130,13 +130,11 @@ You can specify:
 ``packages.archives``
 -------------------
 
-'Archive file` handler for common 'download' and 'checksum' states; extraction state based on `format` value.
+'Archive file` handler for common 'download' and 'checksum' states. All formats recognized by `salt.states.archive.extracted` (tar, rar, zip, etc) will be extracted. Alternatively `raw` formats are supported (`raw`, `bin`,) for standard and binary executable files.
 
 * ``wanted`` archive package software, which will be installed by extraction.
 * ``unwanted`` archive package software, which are uninstalled by directory removal.
 * ``required archive packages`` on which any of the ``wanted`` items depend on. Optional.
-
-.. note:: Supports `tar` formats that `salt.states.archive.extracted` understands (tar, rar, zip, etc). The `packages.archives` state can be extended.
 
 
 ``packages.snaps``

--- a/packages/defaults.yaml
+++ b/packages/defaults.yaml
@@ -34,6 +34,7 @@ packages:
       states: []
       pkgs: []
   archives:
+    types: ('tar','zip', 'rar',)
     wanted: {}    #note: dict
     unwanted: []
     required:

--- a/pillar.example
+++ b/pillar.example
@@ -49,7 +49,7 @@ packages:
   archives:
     wanted:
       terminator:
-        dest: /usr/local/terminator
+        dest: /usr/local/terminator/
         options: '--strip-components=1'  #recommended option, but beware tarbombs
         dl:
           format: tar
@@ -57,13 +57,24 @@ packages:
           #hashurl: https://launchpad.net/terminator/gtk3/1.91/+download/terminator-1.91.tar.gz/+md5
           hashsum: md5=2eed999d7a41f2e18eaa511bbbf80f58
       phantomjs:
-        dest: /usr/local/src    #beware tarbombs
+        dest: /usr/local/src/    #beware tarbombs
         user: root
         mode: '0700'
         dl:
           format: tar
           source: https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
           hashsum: md5=1c947d57fce2f21ce0b43fe2ed7cd361
+      blockbox:
+        dest: /usr/local/src/
+        dl:
+          format: raw
+          source: https://raw.githubusercontent.com/openstack/cinder/master/contrib/block-box/docker-compose.yml
+          hashsum: 1751f8e4f6b4cddd8c4843a0f4473274
+      kubectl:
+        dest: /usr/local/bin
+        dl:
+          format: bin
+          source: https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/darwin/amd64/kubectl
     unwanted:
       - /usr/local/boring_archive_software
 


### PR DESCRIPTION
This PR  is improved implementation `packages.archives` state.  

1. Don't lose archive name => pull the filename from end of the URL so its proper filename.
```
{%- set archivename = archive.dl.source.split("/")[-1] %}
``` 
2. Allow support for downloading **raw** file format (i.e. `format: yaml`, `format: txt`, etc).  This is useful for downloading some kind of xml/json/yaml file, for docker compose for example.
3. Skip `archive.extracted` when **raw** file format (i.e. not a linux archive format) since you cannot archive extract a yaml file ;-)
4. Remove superfluous `packages-archive-wanted-install-{{ package }}.cmd.run`.

Verified on vagrant (three files: 2 = tar.gz and 1 = yaml).
```
Succeeded: 27 (changed=15)
Failed:     0
-------------
Total states run:     27
Total run time:   87.560 s
```