### PR TITLE
tar is bundled with MacOS. Fix #38

### DIFF
--- a/packages/archives.sls
+++ b/packages/archives.sls
@@ -2,7 +2,7 @@
 # vim: ft=sls
 {% from "packages/map.jinja" import packages with context %}
 
-{% set req_packages = packages.pkgs.required.pkgs + ['curl', 'tar', 'bzip2', 'gzip',] %}
+{% set req_packages = packages.pkgs.required.pkgs + packages.archives.pkgs.required %}
 include:
   - packages.pkgs
 

--- a/packages/defaults.yaml
+++ b/packages/defaults.yaml
@@ -34,6 +34,8 @@ packages:
       states: []
       pkgs: []
   archives:
+    pkgs:
+      required: ['curl', 'bzip2', 'gzip']
     wanted: {}    #note: dict
     unwanted: []
     required:


### PR DESCRIPTION
This PR fixes issue #38.  Tar is always bundled with MacOS so no homebrew package exists.