### PR TITLE
Retry packages.archives download state

### DIFF
--- a/packages/archives.sls
+++ b/packages/archives.sls
@@ -49,6 +49,11 @@ packages-archive-wanted-download-{{ package }}:
   cmd.run:
     - name: curl -s -L -o {{ packages.tmpdir }}/{{ archivename }} {{ archive.dl.source }}
     - unless: test -f {{ packages.tmpdir }}/{{ archivename }}/
+    - retry:
+        attempts: 5
+        until: True
+        interval: 60
+        splay: 10
 
       {%- if 'hashsum' in archive.dl and archive.dl.hashsum %}
          {# see https://github.com/saltstack/salt/pull/41914 #}


### PR DESCRIPTION
Sometimes when using the `packages.archives` state I get a timeout. There are various potential causes - so a retry would be useful 

```
[ERROR   ] Failed to cache https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubectl: Error: HTTP 599: Timeout while connecting reading https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubectl
```