### PR TITLE
minor fix for temp file.directory state

### DIFF
--- a/packages/archives.sls
+++ b/packages/archives.sls
@@ -29,7 +29,7 @@ packages-archive-unwanted-{{ file_or_directory }}:
 packages-archive-wanted-target-{{ package }}-directory:
   file.directory:
     - names:
-      - {{ packages.tmpdir }}/tmp
+      - {{ packages.tmpdir or '/tmp' }}
       - {{ archive.dest }}
     - user: {{ 'root' if 'user' not in archive else archive.user }}
     - mode: {{ '0755' if 'mode' not in archive else archive.mode }}


### PR DESCRIPTION
Fix this
```
          ID: packages-archive-wanted-target-kubectl-directory
    Function: file.directory
        Name: /tmp/tmp
      Result: True
     Comment: The directory /tmp/tmp is in the correct state
```