### PR TITLE
pip: allow to drop a config file first

### DIFF
--- a/packages/files/pip.conf
+++ b/packages/files/pip.conf
@@ -1,0 +1,6 @@
+{%- for section, settings in config.items()|sort -%}
+[{{ section }}]
+{%- for key, value in settings.items()|sort %}
+{{ key }} = {{ value }}
+{%- endfor %}
+{%  endfor %}

--- a/packages/pips.sls
+++ b/packages/pips.sls
@@ -6,11 +6,23 @@
 {% set req_pkgs = packages.pips.required.pkgs %}
 {% set wanted_pips = packages.pips.wanted %}
 {% set unwanted_pips = packages.pips.unwanted %}
+{% set pip_config = packages.pips.config %}
 
 ### REQ PKGS (without these, some of the WANTED PIPS will fail to install)
 pip_req_pkgs:
   pkg.installed:
     - pkgs: {{ req_pkgs }}
+
+{% if pip_config %}
+pip_config:
+  file.managed:
+    - name: /etc/pip.conf
+    - source: salt://{{ slspath }}/files/pip.conf
+    - template: jinja
+    - makedirs: True
+    - context:
+        config: {{ pip_config|json }}
+{% endif %}
 
 ### PYTHON PKGS to install using PIP
 # (requires the python-pip deb/rpm installed, either by the system or listed in
@@ -25,6 +37,9 @@ pip_req_pkgs:
         {% for dep in req_states %}
       - sls: {{ dep }}
         {% endfor %}
+      {% endif %}
+      {% if pip_config %}
+      - file: pip_config
       {% endif %}
 {% endfor %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -31,6 +31,11 @@ packages:
       - campbel
       - reverse_geocode
       - indy-crypto
+    config:
+      global:
+        timeout: 120
+        default-timeout: 120
+        proxy: http://proxy.example.com:3128
   gems:
     wanted:
       - progressbar


### PR DESCRIPTION
Allow to configure pip first.

Helps when you need to either use a proxy, or an alternate index.