### PR TITLE
Python3 is default on Suse 15.0

### DIFF
--- a/packages/osfamilymap.yaml
+++ b/packages/osfamilymap.yaml
@@ -4,7 +4,7 @@ Suse:
   pips:
     required:
       pkgs:
-        - python2-pip
+        - python3-pip
 
 Debian:
   pips:


### PR DESCRIPTION
This PR is related to https://github.com/saltstack-formulas/docker-formula/issues/198

Here is state _before and after_ running salt-bootstrap on OpenSUSE 15.0
```
selenium-node:~/opensds-installer/salt # pip --version
pip 10.0.1 from /usr/lib/python3.6/site-packages/pip (python 3.6)
selenium-node:~/opensds-installer/salt # rpm -qa | grep pip
python3-pip-10.0.1-lp150.1.2.noarch
````
To avoid breaking python on latest Suse we should default to python3-pip.  
