### PR TITLE
pip states broken on python3 [suse 15]

### DIFF
--- a/packages/pips.sls
+++ b/packages/pips.sls
@@ -22,6 +22,7 @@ packages pips install {{ pn }}:
     - name: /usr/bin/pip install {{ pn }}
        {%- else %}
   pip.installed:
+    - name: {{ pn }}
     - reload_modules: true
        {%- endif %}
     - require:
@@ -39,7 +40,7 @@ packages pips remove {{ upn }}:
   cmd.run:
     - name: /usr/bin/pip uninstall {{ pn }}
        {%- else %}
-  pip.removed
+  pip.removed:
     - name: {{ upn }}
        {%- endif %}
 {% endfor %}

--- a/packages/pips.sls
+++ b/packages/pips.sls
@@ -16,9 +16,14 @@ pip_req_pkgs:
 # (requires the python-pip deb/rpm installed, either by the system or listed in
 # the required packages
 {% for pn in wanted_pips %}
-{{ pn }}:
+packages pips install {{ pn }}:
+       {%- if grains.os_family in ('Suse',) %}  ##workaround https://github.com/saltstack-formulas/docker-formula/issues/198
+  cmd.run:
+    - name: /usr/bin/pip install {{ pn }}
+       {%- else %}
   pip.installed:
     - reload_modules: true
+       {%- endif %}
     - require:
       - pkg: pip_req_pkgs
       {% if req_states %}
@@ -29,6 +34,12 @@ pip_req_pkgs:
 {% endfor %}
 
 {% for upn in unwanted_pips %}
-{{ upn }}:
+packages pips remove {{ upn }}:
+       {%- if grains.os_family in ('Suse',) %}
+  cmd.run:
+    - name: /usr/bin/pip uninstall {{ pn }}
+       {%- else %}
   pip.removed
+    - name: {{ upn }}
+       {%- endif %}
 {% endfor %}


### PR DESCRIPTION
This PR is workaround for broken pip.install/remove states with python3 (on Suse 15_0)

See: https://github.com/saltstack-formulas/docker-formula/issues/198


VERIFIED ON SUSE 15.0
```
          ID: packages pips install tox
    Function: cmd.run
        Name: /usr/bin/pip install tox
      Result: True
     Comment: Command "/usr/bin/pip install tox" run
     Started: 09:08:12.537061
    Duration: 681.493 ms
     Changes:
              ----------
              pid:
                  5206
              retcode:
                  0
              stderr:
                  You are using pip version 10.0.1, however version 19.0.3 is available.
                  You should consider upgrading via the 'pip install --upgrade pip' command.
              stdout:
                  Requirement already satisfied: tox in /usr/lib/python3.6/site-packages (3.7.0)
                  Requirement already satisfied: setuptools>=30.0.0 in /usr/lib/python3.6/site-packages (from tox) (38.4.1)
                  Requirement already satisfied: virtualenv>=1.11.2 in /usr/lib/python3.6/site-packages (from tox) (16.4.0)
                  Requirement already satisfied: py<2,>=1.4.17 in /usr/lib/python3.6/site-packages (from tox) (1.5.2)
                  Requirement already satisfied: filelock<4,>=3.0.0 in /usr/lib/python3.6/site-packages (from tox) (3.0.10)
                  Requirement already satisfied: six<2,>=1.0.0 in /usr/lib/python3.6/site-packages (from tox) (1.11.0)
                  Requirement already satisfied: toml>=0.9.4 in /usr/lib/python3.6/site-packages (from tox) (0.10.0)
                  Requirement already satisfied: pluggy<1,>=0.3.0 in /usr/lib/python3.6/site-packages (from tox) (0.8.1)
----------
          ID: packages pips install click
    Function: cmd.run
        Name: /usr/bin/pip install click
      Result: True
     Comment: Command "/usr/bin/pip install click" run
     Started: 09:08:13.219332
    Duration: 641.332 ms
     Changes:
              ----------
              pid:
                  5212
              retcode:
                  0
              stderr:
                  You are using pip version 10.0.1, however version 19.0.3 is available.
                  You should consider upgrading via the 'pip install --upgrade pip' command.
              stdout:
                  Requirement already satisfied: click in /usr/lib64/python3.6/site-packages (7.0)
```

