### PR TITLE
Add 'pips.config' dict to defaults

### DIFF
--- a/packages/defaults.yaml
+++ b/packages/defaults.yaml
@@ -13,6 +13,7 @@ packages:
   pips:
     wanted: []
     unwanted: []
+    config: []
     required:
       states: []
       pkgs: []


### PR DESCRIPTION
Fix **rendering error** when no `packages.pips.config" pillar is unavailable.