### PR TITLE
feat(internet): add retries for internet dependent states

### DIFF
--- a/packages/archives.sls
+++ b/packages/archives.sls
@@ -45,11 +45,7 @@ packages-archive-wanted-download-{{ package }}:
   cmd.run:
     - name: curl -s -L -o {{ packages.tmpdir }}/{{ archivename }} {{ archive.dl.source }}
     - unless: test -f {{ packages.tmpdir }}/{{ archivename }}
-    - retry:
-        attempts: 2
-        until: True
-        interval: 60
-        splay: 10
+    - retry: {{ packages.retry_options|json }}
 
       {%- if 'hashsum' in archive.dl and archive.dl.hashsum %}
          {# see https://github.com/saltstack/salt/pull/41914 #}
@@ -96,6 +92,7 @@ packages-archive-wanted-download-{{ package }}:
        {%- else %}
     - skip_verify: True
        {%- endif %}
+    - retry: {{ packages.retry_options|json }}
 
    {% endif %} 
 {%- endfor %}

--- a/packages/defaults.yaml
+++ b/packages/defaults.yaml
@@ -48,3 +48,9 @@ packages:
     unwanted: []
     required:
       archives: {}    #note: dict
+  retry_options:
+    # https://docs.saltstack.com/en/latest/ref/states/requisites.html#retrying-states
+    attempts: 3
+    until: True
+    interval: 60
+    splay: 10

--- a/packages/gems.sls
+++ b/packages/gems.sls
@@ -18,6 +18,7 @@ include:
 gem_req_pkgs:
   pkg.installed:
     - pkgs: {{ req_pkgs | json }}
+    - retry: {{ packages.retry_options|json }}
 
 ### GEMS to install
 # (requires the ruby/rubygem deb/rpm installed, either by the system or listed in
@@ -32,6 +33,7 @@ gem_req_pkgs:
       - sls: {{ dep }}
         {% endfor %}
       {% endif %}
+    - retry: {{ packages.retry_options|json }}
 {% endfor %}
 
 {% for ugm in unwanted_gems %}

--- a/packages/npms.sls
+++ b/packages/npms.sls
@@ -66,6 +66,7 @@ wanted_npms:
       - sls: {{ dep }}
         {% endfor %}
       {% endif %}
+    - retry: {{ packages.retry_options|json }}
 
 {% for upn in unwanted_npms %}
 {{ upn }}:

--- a/packages/pips.sls
+++ b/packages/pips.sls
@@ -54,6 +54,7 @@ packages pips install {{ pn }}:
       {% if pip_config %}
       - file: pip_config
       {% endif %}
+    - retry: {{ packages.retry_options|json }}
 {% endfor %}
 
 {% for upn in unwanted_pips %}

--- a/packages/pkgs.sls
+++ b/packages/pkgs.sls
@@ -26,6 +26,7 @@ pkg_req_pkgs:
       - sls: {{ dep }}
       {% endfor %}
     {% endif %}
+    - retry: {{ packages.retry_options|json }}
 
 {% if held_packages != {} %}
 held_pkgs:
@@ -47,6 +48,7 @@ held_pkgs:
         {% for dep in req_states %}
       - sls: {{ dep }}
         {% endfor %}
+    - retry: {{ packages.retry_options|json }}
 {% endif %}
 
 wanted_pkgs:
@@ -62,6 +64,7 @@ wanted_pkgs:
       - sls: {{ dep }}
         {% endfor %}
       {% endif %}
+    - retry: {{ packages.retry_options|json }}
 
 unwanted_pkgs:
   pkg.purged:

--- a/packages/snaps.sls
+++ b/packages/snaps.sls
@@ -38,6 +38,7 @@ extend:
         - sls: {{ dep }}
       {% endfor %}
     {% endif %}
+      - retry: {{ packages.retry_options|json }}
 
 {% if packages.snaps.symlink %}
 {# classic confinement requires snaps under /snap or symlink from #}
@@ -72,6 +73,7 @@ packages-snapd-{{ snap }}-wanted:
     - require:
       - pkg: pkg_req_pkgs
       - pkg: unwanted_pkgs
+    - retry: {{ packages.retry_options|json }}
 {% endfor %}
 
 ### SNAPS to install in classic mode
@@ -84,6 +86,7 @@ packages-snapd-{{ snap }}-classic:
     - require:
       - pkg: pkg_req_pkgs
       - pkg: unwanted_pkgs
+    - retry: {{ packages.retry_options|json }}
 {% endfor %}
 
 ### SNAPS to uninstall

--- a/pillar.example
+++ b/pillar.example
@@ -122,3 +122,9 @@ packages:
   remote_pkgs:
     zoom: 'https://zoom.us/client/latest/zoom_amd64.deb'
 
+  retry_options:
+    # https://docs.saltstack.com/en/latest/ref/states/requisites.html#retrying-states
+    attempts: 5
+    until: True
+    interval: 30
+    splay: 20


### PR DESCRIPTION
This PR adds retry for internet dependent states.

For example workaround "Temporary failure in name resolution" issue.
```
          ID: packages-archive-wanted-download-kubectl
    Function: file.managed
        Name: /usr/local/bin/kubectl
      Result: False
     Comment: Failed to cache 
https://storage.googleapis.com/kubernetes-release/release/v1.12.3/bin/linux/amd64/kubectl: 
Error: [Errno -3] Temporary failure in name resolution reading 
https://storage.googleapis.com/kubernetes-release/release/v1.12.3/bin/linux/amd64/kubectl
     Started: 03:26:55.100108
    Duration: 2635.434 ms
```
