### PR TITLE
fix(python): os default to python3

### DIFF
--- a/packages/osfamilymap.yaml
+++ b/packages/osfamilymap.yaml
@@ -14,7 +14,7 @@ Debian:
   pips:
     required:
       pkgs:
-        - python-pip
+        - python3-pip
   gems:
     required:
       pkgs:
@@ -30,8 +30,7 @@ RedHat:
         - epel
       pkgs:
         - gcc
-        - python-devel
-        - python2-pip
+        - python3-pip
   gems:
     required:
       pkgs:
@@ -41,7 +40,7 @@ FreeBSD:
   pips:
     required:
       pkgs:
-        - devel/py-pip
+        - devel/py36-pip
   gems:
     required:
       pkgs:


### PR DESCRIPTION
This PR updates osfamilymap.yaml for python3.

Move away from python2 per https://python3statement.org/

The problem is, when your OS only has python3, but formulas reference python2 packages, then python2 gets installed and potentially changes `python` symlink back to `python2`.

I cannot find a RedHat python3-devel package either.