### PR TITLE
WIP feat(centos-8): added centos 8 support

### DIFF
--- a/packages/map.jinja
+++ b/packages/map.jinja
@@ -4,6 +4,7 @@
 {% import_yaml 'packages/defaults.yaml' as defaults %}
 {% import_yaml 'packages/osfamilymap.yaml' as osfamilymap %}
 {% import_yaml 'packages/osmap.yaml' as osmap %}
+{% import_yaml 'packages/osfingermap.yaml' as osfingermap %}
 
 {% set packages = salt['grains.filter_by'](
     defaults,
@@ -13,7 +14,11 @@
         merge = salt['grains.filter_by'](
             osmap,
             grain='os',
-            merge = salt['pillar.get']('packages', {}),
+            merge = salt['grains.filter_by'](
+              osfingermap,
+              grain='osfinger',
+              merge = salt['pillar.get']('packages', {}),
+              ),
         ),
     ),
     base='packages')

--- a/packages/osfamilymap.yaml
+++ b/packages/osfamilymap.yaml
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
+---
 Suse:
   pips:
     required:
@@ -20,10 +21,6 @@ Debian:
       pkgs:
         - ruby
 RedHat:
-  pkgs:
-    required:
-      pkgs:
-        - yum-plugin-versionlock
   pips:
     required:
       states:

--- a/packages/osfingermap.yaml
+++ b/packages/osfingermap.yaml
@@ -1,26 +1,28 @@
 ---
-RedHat:
+CentOS Linux-6:
   pkgs:
     required:
       pkgs:
         - yum-plugin-versionlock
 
-Fedora:
+CentOS Linux-7:
   pkgs:
     required:
       pkgs:
-        - python2-dnf-plugin-versionlock
+        - yum-plugin-versionlock
+
+CentOS Linux-8:
+  pkgs:
+    required:
+      pkgs:
+        - python3-dnf-plugin-versionlock
   pips:
     required:
       states: []
       pkgs:
         - gcc
-        - python2-pip
-        - python2-devel
+        - python3-pip
+        - python3-devel
   snaps:
     collides: ['snap']
     symlink: true
-
-CentOS:
-  snaps:
-    package:


### PR DESCRIPTION
Add centos 8 to osfingermap
moved RedHat/CentOS to osmap and osfingermap to accomodate changes in
package provider versionlock

Do not merge yet, waiting on salt bug: https://github.com/saltstack/salt/issues/54798
Centos 8 uses the wrong package provider, should be `dnf` but it's using `yum`
which results in an error with `yum-plugin-versionlock`, which isn't available on centos-8.