### PR TITLE
Fix imports using tplroot

### DIFF
--- a/packages/archives.sls
+++ b/packages/archives.sls
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
-{%- from "./map.jinja" import packages with context %}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import packages with context %}
 
 {%- set wanted_archives = packages.archives.required.archives %}
 {%- do wanted_archives.update( packages.archives.wanted ) %}

--- a/packages/chocolatey.sls
+++ b/packages/chocolatey.sls
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
-{%- from "./map.jinja" import packages with context %}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import packages with context %}
 
 {%- if grains['os'] == 'Windows' %}
 

--- a/packages/map.jinja
+++ b/packages/map.jinja
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # vim: ft=jinja
+{%- set tplroot = tpldir.split('/')[0] %}
 
-{%- import_yaml './defaults.yaml' as defaults %}
-{%- import_yaml './osfamilymap.yaml' as osfamilymap %}
-{%- import_yaml './osmap.yaml' as osmap %}
-{%- import_yaml './osfingermap.yaml' as osfingermap %}
+{%- import_yaml tplroot ~ '/defaults.yaml' as defaults %}
+{%- import_yaml tplroot ~ '/osfamilymap.yaml' as osfamilymap %}
+{%- import_yaml tplroot ~ '/osmap.yaml' as osmap %}
+{%- import_yaml tplroot ~ '/osfingermap.yaml' as osfingermap %}
 
 {%- set packages = salt['grains.filter_by'](
     defaults,

--- a/packages/npms.sls
+++ b/packages/npms.sls
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
-{%- from "./map.jinja" import packages with context %}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import packages with context %}
 
 {%- set req_states = packages.npms.required.states %}
 {%- set req_pkgs = packages.npms.required.pkgs %}

--- a/packages/osfamilymap.yaml
+++ b/packages/osfamilymap.yaml
@@ -42,9 +42,8 @@ FreeBSD:
         - lang/ruby25
         - devel/ruby-gems
 
-#Windows:
-#  chocolatey:
-#    required:
-#      pkgs:
-#        - chocolatey
-#
+Windows:
+  chocolatey:
+    required:
+      pkgs:
+        - chocolatey

--- a/packages/osfamilymap.yaml
+++ b/packages/osfamilymap.yaml
@@ -42,8 +42,9 @@ FreeBSD:
         - lang/ruby25
         - devel/ruby-gems
 
-Windows:
-  chocolatey:
-    required:
-      pkgs:
-        - chocolatey
+#Windows:
+#  chocolatey:
+#    required:
+#      pkgs:
+#        - chocolatey
+#

--- a/packages/pkgs.sls
+++ b/packages/pkgs.sls
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
-{%- from "./map.jinja" import packages with context %}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import packages with context %}
 
 {%- set req_states = packages.pkgs.required.states %}
 {%- set req_packages = packages.pkgs.required.pkgs %}

--- a/packages/remote_pkgs.sls
+++ b/packages/remote_pkgs.sls
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
-{%- from "./map.jinja" import packages with context %}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import packages with context %}
 
 {%- set wanted_rem_pkgs = packages.remote_pkgs %}
 

--- a/packages/snaps.sls
+++ b/packages/snaps.sls
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
-{%- from "./map.jinja" import packages with context %}
+
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- from tplroot ~ "/map.jinja" import packages with context %}
 
 # As we are 'extend'ing pkg_req_pkgs and unwanted_pkgs, we need to concatenate
 # the attributes correctly (see #17)


### PR DESCRIPTION
### PR progress checklist (to be filled in by reviewers)

<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?

No.

### Describe the changes you're proposing
The problem was that salt-minion didn't cache all the files used by the formula on windows clients. 
In fact when I applied the `packages.chocolatey` state only the `chocolatey.sls` file was found on the cache folder. 
This triggered an error because salt couldn't find the `map.jinja` file. 

Importing files using `tplroot` instead of using relative path seems to fix the problem.




